### PR TITLE
Fetch tags before GoReleaser and skip releases for workflow-only pushes

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".github/**"
 
 permissions:
   contents: write
@@ -23,6 +25,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
+
+      - name: Fetch tags
+        if: steps.bump.outputs.new_tag != ''
+        run: git fetch --force --tags
 
       - name: Install Go
         uses: actions/setup-go@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow to prevent unnecessary builds when workflow files are modified.
  * Enhanced tag handling during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->